### PR TITLE
Live-dead grid vs. visual; fixed asserts

### DIFF
--- a/error.c
+++ b/error.c
@@ -3,6 +3,7 @@
 // Very simple error system, mostly for readability.
 //
 #include "error.h"
+#include <assert.h>
 
 
 //
@@ -23,5 +24,9 @@ const char* Error_GetString(
         case ERROR_FILE_OPEN_FAILURE: return "Unable to open requested initial file";
         case ERROR_INVALID_FILE_FORMAT: return "Initial file is incorrect format";
     }
+
+    // New error was added, but not in this table
+    //
+    assert(0);
     return "Unknown Error Code";
 }

--- a/gol.c
+++ b/gol.c
@@ -14,11 +14,19 @@
 #include <stdbool.h>
 #include <ctype.h>
 #include <stdlib.h>
+#include <assert.h>
 
 
 // Number of generates to run the program for
 //
 #define GENERATIONS_TO_RUN 4
+
+// Living and dead-cell representations
+// -- This are also the expected file symbols
+//
+static const uint8_t DEAD_CELL_CHAR = '.';
+static const uint8_t LIVE_CELL_CHAR = 'X';
+
 
 // NOTE: Having trouble with my build system
 // The time.h header in mingwin does not seem to be right.
@@ -85,16 +93,17 @@ int main(int argc, char* argv[])
     srand(time(NULL));
 
     // Initialze with starting pattern for first generation
+    // This should never fail to return an initial pattern
     //
     initialPattern = Arguments_GetInitialPatternArgument();
-//    CASSERT(initialPattern != NULL)
+    assert(initialPattern != NULL);
     if (CaseInsentitiveStringCompare(initialPattern, ARGUMENT_PATTERN_RANDOM))
     {
         Grid_InitializeAsRandom();
     }
     else
     {
-        result = Grid_InitializeFromFile(initialPattern);
+        result = Grid_InitializeFromFile(initialPattern, DEAD_CELL_CHAR, LIVE_CELL_CHAR);
         if (result != NO_ERROR)
         {
             goto EXIT;
@@ -104,7 +113,7 @@ int main(int argc, char* argv[])
     // Display 'file name' and grid for first generation
     //
     fprintf(stdout, "%s\n", initialPattern);
-    Grid_Write(stdout);
+    Grid_Write(stdout, DEAD_CELL_CHAR, LIVE_CELL_CHAR);
     printf("\n");
 
     // Generate and display the rest of the generations
@@ -112,7 +121,7 @@ int main(int argc, char* argv[])
     while (Grid_GetGenerationCount() < GENERATIONS_TO_RUN)
     {
         Grid_AdvanceToNextGeneration();
-        Grid_Write(stdout);
+        Grid_Write(stdout, DEAD_CELL_CHAR, LIVE_CELL_CHAR);
         printf("\n");
     }
 

--- a/golgrid.h
+++ b/golgrid.h
@@ -11,7 +11,7 @@
 // Set as first generation with contents from file
 // Returns error status
 //
-int32_t Grid_InitializeFromFile(const char* patternFileName);
+int32_t Grid_InitializeFromFile(const char* patternFileName, char deadCell, char liveCell);
 
 // Set the first generation od the grid to random contents
 //
@@ -19,7 +19,7 @@ void Grid_InitializeAsRandom(void);
 
 // Write the grid to a file stream
 //
-void Grid_Write(FILE* stream);
+void Grid_Write(FILE* stream, char deadCell, char liveCell);
 
 // Run the rules on the current grid
 //

--- a/makefile
+++ b/makefile
@@ -5,8 +5,8 @@
 PROGRAM_NAME = gol.exe
 CC = gcc
 LINK = gcc
-CFLAGS = -c -Os -std=c99 -Wall
-LINK_FLAGS = -Xlinker -Map=output.map -o $(PROGRAM_NAME)
+CFLAGS = -c -Os -std=c99 -Wall -DNDEBUG
+LINK_FLAGS = -o $(PROGRAM_NAME)
 
 OBJS = \
 	arguments.o \
@@ -22,6 +22,7 @@ gol: $(OBJS)
 	$(CC) $(CFLAGS) $<
 
 debug: CFLAGS += -g
+debug: CFLAGS := $(filter-out -DNDEBUG,$(CFLAGS))
 debug: gol
 
 


### PR DESCRIPTION
Reverted to an earlier style where 0 and 1 were stored in the actual grid (as opposed to storing the visual elements).
This allows just adding the result of the get, as opposed to if (alive) { ++neightbors. }

The visual representation should not be part of the grid by default. This is a visual element, representing data, not the actual data element. The grid owns the data elements and the data logic, not visual logic. (WriteGrid probably doesn't belong in the Grid class, but the visual elements are passed).

FIxed the asserts, both in the code and in the makefile build.

Some minor variable renaming.